### PR TITLE
handling int and float numpy dtypes

### DIFF
--- a/moj.ladisk.si/mojladisksi.py
+++ b/moj.ladisk.si/mojladisksi.py
@@ -68,11 +68,18 @@ def data_to_json(object):
     """
     Pripravi posredovan objekt za JSON serilizacijo. V `pripravi_resitev`?
     """
+
     if isinstance(object, np.ndarray):
         return {'type': str(np.ndarray), 'dtype': str(object.dtype), 'tolist': object.tolist()}
 
     if isinstance(object, complex):
         return (object.real, object.imag)
+
+    if type(object) in np.sctypes['int'] + np.sctypes['uint']:
+        return int(object)
+    
+    if type(object) in np.sctypes['float']:
+        return float(object)
 
     raise TypeError(f'Object of type {type(object)} not serializable')
 


### PR DESCRIPTION
Kadar seznam integerjev ali floatov naredimo iz numpy array-a (npr. `list(np.arange(10))`), je tip podatkov v tem seznamu `np.int32` namesto `int` (v tem konkretnem primeru). Numpy tipov ne moremo serilizirati v json, treba jih je predhodno pretvoriti v ekvivalenten Python tip.